### PR TITLE
Update equipment model for DS Voulge & Leonine Mask

### DIFF
--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -5895,7 +5895,7 @@ INSERT INTO `item_equipment` VALUES (16147,'fourth_haube',68,0,14785,222,0,0,16,
 INSERT INTO `item_equipment` VALUES (16148,'cobra_cap',68,0,2589730,219,0,0,16,0);
 INSERT INTO `item_equipment` VALUES (16149,'cobra_cloche',68,0,3850780,220,0,0,16,0);
 INSERT INTO `item_equipment` VALUES (16150,'saurian_helm',73,0,2141649,6,0,0,16,0);
-INSERT INTO `item_equipment` VALUES (16151,'leonine_mask',75,0,2363683,33,0,0,16,0);
+INSERT INTO `item_equipment` VALUES (16151,'leonine_mask',75,0,2363683,51,0,0,16,0);
 INSERT INTO `item_equipment` VALUES (16152,'hissho_hachimaki',71,0,6146,141,0,0,16,0);
 INSERT INTO `item_equipment` VALUES (16153,'reikyo_hairpin',72,0,4194303,0,0,0,16,0);
 INSERT INTO `item_equipment` VALUES (16154,'karura_hachigane',73,0,16384,4,0,5,16,0);
@@ -7946,8 +7946,8 @@ INSERT INTO `item_equipment` VALUES (18222,'fortitude_axe',73,0,2097281,335,0,0,
 INSERT INTO `item_equipment` VALUES (18223,'toporok',73,0,2097281,92,0,0,1,0);
 INSERT INTO `item_equipment` VALUES (18224,'toporok_+1',73,0,2097281,92,0,0,1,0);
 INSERT INTO `item_equipment` VALUES (18225,'blizzard_toporok',73,0,2097281,92,0,0,1,0);
-INSERT INTO `item_equipment` VALUES (18226,'darksteel_voulge',55,0,1,363,0,0,1,0);
-INSERT INTO `item_equipment` VALUES (18227,'dst._voulge_+1',55,0,1,363,0,0,1,0);
+INSERT INTO `item_equipment` VALUES (18226,'darksteel_voulge',55,0,1,364,0,0,1,0);
+INSERT INTO `item_equipment` VALUES (18227,'dst._voulge_+1',55,0,1,364,0,0,1,0);
 INSERT INTO `item_equipment` VALUES (18228,'battery',10,0,4194303,0,0,0,8,4);
 INSERT INTO `item_equipment` VALUES (18229,'kilo_battery',30,0,4194303,0,0,0,8,4);
 INSERT INTO `item_equipment` VALUES (18230,'mega_battery',50,0,4194303,0,0,0,8,4);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Model ID fixes for:
Darksteel Voulge and +1 - They should share model with [Lyft Voulge](https://ffxiclopedia.fandom.com/wiki/Lyft_Voulge).  
Leonine Mask - Should share a model with [Tiger Mask](https://ffxiclopedia.fandom.com/wiki/Tiger_Mask).
